### PR TITLE
fix: reset auto-save state when switching files

### DIFF
--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -29,7 +29,7 @@ export function useAutoSave({ content, filePath, onSave, delay = 15000, paused =
 
   // Capture the initial content for a file once it has loaded
   useEffect(() => {
-    if (filePath && needsResetRef.current) {
+    if (filePath && needsResetRef.current && content != null) {
       initialContentRef.current = content;
       setLastSaved(content);
       needsResetRef.current = false;

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -13,13 +13,28 @@ export function useAutoSave({ content, filePath, onSave, delay = 15000, paused =
   const [lastSaved, setLastSaved] = useState<string>('');
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const initialContentRef = useRef<string>('');
+  const needsResetRef = useRef(false);
 
+  // When the file path changes mark that we need to capture the new initial content
   useEffect(() => {
-    if (filePath && content !== initialContentRef.current) {
-      initialContentRef.current = content;
-      setLastSaved(content);
+    if (filePath) {
+      needsResetRef.current = true;
+    } else {
+      // No file selected – clear references
+      initialContentRef.current = '';
+      setLastSaved('');
+      needsResetRef.current = false;
     }
   }, [filePath]);
+
+  // Capture the initial content for a file once it has loaded
+  useEffect(() => {
+    if (filePath && needsResetRef.current) {
+      initialContentRef.current = content;
+      setLastSaved(content);
+      needsResetRef.current = false;
+    }
+  }, [content, filePath]);
 
   const saveNow = async () => {
     if (!filePath || content === lastSaved || isSaving) {


### PR DESCRIPTION
## Summary
- ensure auto-save captures new file content after switching files

## Testing
- `npm run typecheck` *(fails: Cannot find module './styles/App.module.css' and other missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68a8249926e8832d8afd403341d2a1e4