### PR TITLE
docs: fix auth token comment spelling

### DIFF
--- a/bin/markdown-web.js
+++ b/bin/markdown-web.js
@@ -61,7 +61,7 @@ async function main() {
     if (ngrokAuthToken && ngrokDomain) {
       try {
         const ngrok = await import('@ngrok/ngrok');
-        // Some environments require explicit authtoken setup
+        // Some environments require explicit auth token setup
         try { await ngrok.authtoken(ngrokAuthToken); } catch {}
         const addr = 3001; // local server port
         ngrokListener = await ngrok.connect({ addr, authtoken: ngrokAuthToken, domain: ngrokDomain });


### PR DESCRIPTION
## Summary
- replace "authtoken" with "auth token" in ngrok setup comment

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_b_68a82ef1ea94832d8ac2617399d8573c